### PR TITLE
Add virtual React table example

### DIFF
--- a/virtual-react-table.html
+++ b/virtual-react-table.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Virtual React Table</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-window/umd/react-window.development.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/javascript">
+      const { FixedSizeList } = window["ReactWindow"];
+      const data = Array.from({ length: 1000 }, (_, i) => ({ id: i + 1, name: `Item ${i + 1}` }));
+
+      const Row = ({ index, style }) => (
+        React.createElement("div", { style }, `${data[index].id} - ${data[index].name}`)
+      );
+
+      const App = () =>
+        React.createElement(FixedSizeList, {
+          height: 300,
+          itemCount: data.length,
+          itemSize: 35,
+          width: 300,
+        }, Row);
+
+      ReactDOM.createRoot(document.getElementById("root")).render(
+        React.createElement(App)
+      );
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `virtual-react-table.html` example using React Window for virtualization

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b56f3533d48325a884f5b230a238fc